### PR TITLE
product_imagesテーブルの作成

### DIFF
--- a/app/models/product_image.rb
+++ b/app/models/product_image.rb
@@ -1,0 +1,5 @@
+class ProductImage < ApplicationRecord
+  belongs_to :product
+
+  validates :image, presence: true
+end

--- a/db/migrate/20200817085741_create_product_images.rb
+++ b/db/migrate/20200817085741_create_product_images.rb
@@ -1,0 +1,9 @@
+class CreateProductImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :product_images do |t|
+      t.string :image, null: false
+      t.integer :product_id, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,35 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_08_17_085741) do
+
+  create_table "product_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "image", null: false
+    t.integer "product_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "nickname", null: false
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+end

--- a/test/fixtures/product_images.yml
+++ b/test/fixtures/product_images.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/product_image_test.rb
+++ b/test/models/product_image_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ProductImageTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
商品出品の際、投稿した画像を管理するためのproduct_imagesテーブルを作成する。

# why
画像は１つの商品につき複数投稿できるようにする必要があるため、個別にテーブルを用意する。