### PR TITLE
商品詳細表示 サーバサイド 実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,7 +26,6 @@ class ProductsController < ApplicationController
   def create
     @product = Product.new(product_params)
     if @product.save
-      # redirect_to root_path
     else
       flash[:error] = '必須項目を全て入力してください'
       redirect_to new_product_path

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -26,7 +26,7 @@ class ProductsController < ApplicationController
   def create
     @product = Product.new(product_params)
     if @product.save
-      redirect_to root_path
+      # redirect_to root_path
     else
       flash[:error] = '必須項目を全て入力してください'
       redirect_to new_product_path
@@ -37,6 +37,15 @@ class ProductsController < ApplicationController
     @product = Product.find(params[:id])
     @category = Category.find(@product.category.ancestry)
     @products = Category.where(ancestry: @category.id).map { |c| c.products }.flatten!.shuffle
+  end
+
+  def edit
+  end
+
+  def destroy
+  end
+
+  def purchase
   end
 
   private

--- a/app/views/products/create.html.haml
+++ b/app/views/products/create.html.haml
@@ -4,5 +4,5 @@
   .success
     %h3
       出品が完了しました。
-    = link_to '出品した商品を確認する', "/products/#{@product.id}", method: :get
-    = link_to '続けて商品を出品する', "/products/new", method: :get
+    = link_to '出品した商品を確認する', product_path(@product)
+    = link_to '続けて商品を出品する', new_product_path

--- a/app/views/products/create.html.haml
+++ b/app/views/products/create.html.haml
@@ -1,0 +1,8 @@
+//出品完了画面
+
+.contents.row
+  .success
+    %h3
+      出品が完了しました。
+    = link_to '出品した商品を確認する', "/products/#{@product.id}", method: :get
+    = link_to '続けて商品を出品する', "/products/new", method: :get

--- a/app/views/products/destroy.html.haml
+++ b/app/views/products/destroy.html.haml
@@ -1,0 +1,7 @@
+//削除完了画面
+
+.contents.row
+  .success
+    %h3
+      削除しました。
+    = link_to 'トップページへ戻る', root_path, method: :get

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -104,3 +104,15 @@
                     %i.fa.fa-star
                   .tax
                     （税込）
+
+//出品者にしか商品の情報編集・削除のリンクが踏めないようになっている
+- if user_signed_in? && current_user.id == @product.seller_id
+  .productManage
+    = link_to "商品の編集", product_path(@product.id), class: "productManage__edit"
+    %br
+    = link_to "商品の削除", product_path(@product.id), method: :delete, class: "productManage__delete"
+
+//出品者以外にしか商品購入のリンクが踏めないようになっている
+- if user_signed_in? && current_user.id != @product.seller_id
+  .productManage
+    = link_to "商品を購入する", product_path(@product.id), class: "productManage__purchase"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,11 @@ Rails.application.routes.draw do
     post 'profiles', to: 'users/registrations#create_profile'
     get 'addresses', to: 'users/registrations#new_address'
     post 'addresses', to: 'users/registrations#create_address'
+    post 'products/new', to: 'products#create'
+    get 'products/create', to: 'products#show'
   end
   root 'products#index'
-  resources :products, only: [:index, :new, :create, :show] do
+  resources :products, only: [:index, :new, :create, :show, :edit, :destroy] do
     collection do
       get 'get_children_category', defaults: { format: 'json' }
     end


### PR DESCRIPTION
# What
商品の詳細を確認することができるようにする

# Why
商品出品時に登録した情報が見られるようにするため
ログアウト状態でも商品詳細ページを見ることができるにするため
出品者にしか商品の情報編集・削除のリンクが踏めないようにするため
出品者以外にしか商品購入のリンクが踏めないようにするため

- ログアウト状態で商品ページの閲覧可能
https://gyazo.com/0b28962c8d0149de2bbe1fcf316d7e27
- 出品した情報の確認
https://gyazo.com/ac2e66a0801ca5470e4a4b7639215d9a
- 出品者の商品にのみ情報編集・削除のリンクが表示される
https://gyazo.com/22cb3f7b08e79e5d3d20e44537aca906
- 出品者以外の商品に商品購入のリンクが表示される
https://gyazo.com/37ff5feb79b1e1736b64ff7d049a011f